### PR TITLE
Schedule cron earlier to avoid starting workflow too late

### DIFF
--- a/.github/workflows/register.yml
+++ b/.github/workflows/register.yml
@@ -2,14 +2,14 @@ name: Program Registration
 on:
   workflow_dispatch:
   schedule:
-    - cron: "27 4 * * 1,3"
+    - cron: "15 4 * * 1,3"
     # Sunday/Tuesday 8:30PM PST Registration Time (we are 8 hours behind UTC)
     # Run workflow a few minutes earlier to ensure we can register right on time
     # May need to adjust for Daylight Savings later
 jobs:
   register:
     name: Register
-    timeout-minutes: 5
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Last scheduled run failed because the job started too late for registration